### PR TITLE
EFD-874: Update bind image to work on a standalone docker host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,6 @@ RUN apt-get -y install curl gnupg-curl && \
 RUN mkdir -p /run/named && chmod 0775 /run/named && chown root:bind /run/named
 COPY etc/named.conf /etc/bind/named.conf
 
+EXPOSE 53:53 53:53/udp
+
 CMD ["/usr/sbin/named", "-4", "-f", "-u", "bind", "-g"]

--- a/etc/named.conf
+++ b/etc/named.conf
@@ -19,10 +19,11 @@ acl "local_nets" {
 	127.0.0.0/8;
 // Only need localhost for internal to pod communication.
 // Enable these ranges if needed in the future
-//	169.254.0.0/16;
-//	172.16.0.0/12;
-//	192.168.0.0/16;
-//	10.0.0.0/8;
+	169.254.0.0/16;
+	172.16.0.0/12;
+	192.168.0.0/16;
+	10.0.0.0/8;
+	172.17.0.0/16; // Docker default bridge network
 };
 
 // IPv6 Local Addresses


### PR DESCRIPTION
Changes to enable this container to allow local networks + docker bridge network when running on a standalone CoreOS box.